### PR TITLE
Replace arrow functions with function expressions

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,14 +4,16 @@ const fs = require('fs');
 const path = require('path');
 const PORT = process.env.PORT || 8080;
 const mime = { ".html":"text/html", ".js":"text/javascript", ".css":"text/css", ".json":"application/json", ".png":"image/png", ".webmanifest":"application/manifest+json" };
-http.createServer((req,res)=>{
+http.createServer(function(req, res) {
   let p = req.url.split('?')[0];
   if(p==='/'||p==='') p='/index.html';
   const fp = path.join(__dirname, p);
-  fs.readFile(fp, (err,buf)=>{
+  fs.readFile(fp, function(err, buf) {
     if(err){ res.writeHead(404); return res.end('Not found'); }
     const ext = path.extname(fp).toLowerCase();
     res.writeHead(200, {'Content-Type': mime[ext]||'application/octet-stream'});
     res.end(buf);
   });
-}).listen(PORT, ()=> console.log('Dev server on http://localhost:'+PORT));
+}).listen(PORT, function() {
+  console.log('Dev server on http://localhost:' + PORT);
+});

--- a/sw.js
+++ b/sw.js
@@ -1,1 +1,6 @@
-self.addEventListener('install', e=>self.skipWaiting());self.addEventListener('activate', e=>e.waitUntil(self.clients.claim()));
+self.addEventListener('install', function(e) {
+  self.skipWaiting();
+});
+self.addEventListener('activate', function(e) {
+  e.waitUntil(self.clients.claim());
+});

--- a/tests/sample.test.js
+++ b/tests/sample.test.js
@@ -1,3 +1,3 @@
-test('basic arithmetic works', () => {
+test('basic arithmetic works', function() {
   expect(1 + 1).toBe(2);
 });


### PR DESCRIPTION
## Summary
- Replace arrow functions in server and service worker scripts with classic function expressions for better browser compatibility
- Update tests to avoid arrow syntax

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade0407a6c832c8866a91924f3d718