### PR TITLE
Add Test OCR button and one-off OCR handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -562,7 +562,21 @@
     }
   }
 
-  document.addEventListener('click', function(ev){ var t=ev.target; if(t && t.id==='ocrToggle') ocrToggle(); });
+  function testOCR(){
+    if(!(video && video.readyState>=2)){ toast('Video not ready'); return; }
+    ensureTesseract().then(function(w){
+      if(!w){ toast('Missing vendor'); return; }
+      var snap=getRoiSnapshot();
+      if(!snap){ toast('Video not ready'); return; }
+      var pre=preprocessCanvas(snap);
+      w.recognize(pre).then(function(res){
+        var txt=(res && res.data && res.data.text)||'';
+        var s=txt.trim();
+        toast(s?s:'No text');
+      }).catch(function(){ toast('OCR failed'); });
+    });
+  }
+  document.addEventListener('click', function(ev){ var t=ev.target; if(t && t.id==='ocrToggle') ocrToggle(); else if(t && t.id==='testOCR') testOCR(); });
   if (showBoxesChk){ showBoxesChk.addEventListener('change', drawOverlay); }
   if (autoLogChk){ autoLogChk.addEventListener('change', function(){ drawOverlay(); save(); updatePills(); }); }
   if (scaleModeSel){ scaleModeSel.addEventListener('change', save); }

--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@
           <button id="connectHID" type="button" class="secondary">Connect USB/HID</button>
           <button id="connectBLE" type="button" class="secondary">Connect BLE</button>
           <button id="ocrToggle" type="button" class="secondary">Toggle OCR Box</button>
+          <button id="testOCR" type="button" class="secondary">Test OCR</button>
         </div>
 
         <div class="controls row" style="margin-top:8px">


### PR DESCRIPTION
## Summary
- add Test OCR button beside OCR box toggle in the scanner controls
- implement handler to snapshot ROI, run Tesseract OCR once, and toast text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aded0497b4832cb73de39f44ab1cb1