### PR TITLE
Trim overlong strings before JSON-to-sheet export

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+import { truncateFields } from './xlsx-truncate.js';
 
 // QR-Reader v7.2.3 CORE (no vendor) — fix chain-dot/syntax, keep Show Boxes, OCR ROI, Capture & Analyze, ZIP/XLSX/CSV
 (function(){
@@ -645,6 +646,7 @@
   function exportXlsx(){
     var rows=rowsForExport();
     if(window.XLSX){
+      truncateFields(rows);
       var ws=window.XLSX.utils.json_to_sheet(rows);
       var wb=window.XLSX.utils.book_new();
       window.XLSX.utils.book_append_sheet(wb, ws, 'Log');

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
     </div>
   </main>
 
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
   <script type="module" src="remote.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "jest": "^30.0.5"

--- a/tests/truncateFields.test.js
+++ b/tests/truncateFields.test.js
@@ -1,0 +1,25 @@
+let truncateFields;
+
+beforeAll(async () => {
+  ({ truncateFields } = await import('../xlsx-truncate.js'));
+});
+
+test('truncateFields trims long strings and appends ellipsis', () => {
+  const rows = [{ field: 'a'.repeat(32761) }];
+  truncateFields(rows);
+  expect(rows[0].field.length).toBe(32760);
+  expect(rows[0].field.endsWith('…')).toBe(true);
+});
+
+test('truncateFields leaves short strings unchanged', () => {
+  const rows = [{ field: 'short' }];
+  truncateFields(rows);
+  expect(rows[0].field).toBe('short');
+});
+
+test('truncateFields ignores non-string values', () => {
+  const rows = [{ num: 123, nil: null }];
+  truncateFields(rows);
+  expect(rows[0].num).toBe(123);
+  expect(rows[0].nil).toBe(null);
+});

--- a/xlsx-truncate.js
+++ b/xlsx-truncate.js
@@ -1,0 +1,11 @@
+export function truncateFields(rows){
+  for(let i=0;i<rows.length;i++){
+    const r=rows[i];
+    for(const k in r){
+      const v=r[k];
+      if(typeof v === 'string' && v.length>32760){
+        r[k]=v.slice(0,32759)+'…';
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- truncate overlong field values before XLSX export
- load app.js as module and support ES module tests
- add unit tests for field truncation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aded47a5d0832ca864bc516cdedbcd