### PR TITLE
Remove legacy Tesseract fallback and require worker initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -438,17 +438,9 @@ import { truncateFields } from './xlsx-truncate.js';
       l = lang;
     }
     if(!window.Tesseract.createWorker){
-      setOCRStatus('Ready');
-      ensureTesseract._p = Promise.resolve({
-        recognize:function(img){
-          return window.Tesseract.recognize(img,l,{
-            tessedit_char_whitelist:'0123456789. kgKGlbLBozOZ',
-            preserve_interword_spaces:'1',
-            tessedit_pageseg_mode:'7',
-            user_defined_dpi:'300'
-          });
-        }
-      });
+      setOCRStatus('Missing worker');
+      setStatus('Tesseract worker not available');
+      ensureTesseract._p = Promise.resolve(null);
       return ensureTesseract._p;
     }
     setOCRStatus('Loading…');
@@ -473,20 +465,9 @@ import { truncateFields } from './xlsx-truncate.js';
     }).catch(function(e){
       console.warn('Tesseract init failed', e);
       ensureTesseract._p=null;
-      if(window.Tesseract && window.Tesseract.recognize){
-        setOCRStatus('Ready');
-        return {
-          recognize:function(img){
-            return window.Tesseract.recognize(img,l,{
-              tessedit_char_whitelist:'0123456789. kgKGlbLBozOZ',
-              preserve_interword_spaces:'1',
-              tessedit_pageseg_mode:'7',
-              user_defined_dpi:'300'
-            });
-          }
-        };
-      }
-      setOCRStatus('Missing vendor'); return null;
+      setOCRStatus('Init failed');
+      setStatus('Tesseract initialization failed');
+      return null;
     });
     return ensureTesseract._p;
   }


### PR DESCRIPTION
## Summary
- Require Tesseract.js worker initialization and drop `window.Tesseract.recognize` fallback
- Point worker and core paths at v6.0.1 assets
- Surface initialization failures to the user via status messages

## Testing
- `npm test`
- `node -e` (simulate Tesseract worker init failure)

------
https://chatgpt.com/codex/tasks/task_e_68ae11d44494832c9632560c3b24a378