### PR TITLE
Fix Tesseract resource paths for OCR worker

### DIFF
--- a/app.js
+++ b/app.js
@@ -454,8 +454,8 @@ import { truncateFields } from './xlsx-truncate.js';
     setOCRStatus('Loading…');
     ensureTesseract._p = window.Tesseract.createWorker({
       workerPath:'vendor/worker.min.js',
-      corePath:'vendor/tesseract-core/tesseract-core.wasm.js',
-      langPath:'vendor/lang-data'
+      corePath:'./tesseract-core/tesseract-core.wasm.js',
+      langPath:'./lang-data'
     }).then(function(w){
       return w.load()
         .then(function(){return w.loadLanguage(l);})


### PR DESCRIPTION
## Summary
- Point Tesseract core and language files relative to worker directory

## Testing
- `npm test`
- `node -e "(async () => { const {createWorker}=require('tesseract.js'); const path=require('path'); try { const worker= await createWorker({workerPath:path.resolve('vendor/worker.min.js'), corePath:path.resolve('vendor/tesseract-core/tesseract-core.wasm.js'), langPath:path.resolve('vendor/lang-data')}); await worker.load(); await worker.loadLanguage('eng'); await worker.initialize('eng'); console.log('worker ready'); await worker.terminate(); } catch(e){ console.error('Error', e); } })();"` *(fails: TypeError: langsArr.map is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68af6fc5da4c832c991ed7c0c375f989